### PR TITLE
Implement financial news sentiment analysis pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# Financial-News-Sentiment
+# Financial News Sentiment
+
+This project correlates sentiment extracted from financial news headlines with
+subsequent stock price movements. It fetches headlines from Yahoo Finance,
+computes sentiment using a FinBERT transformer model and performs a regression
+against next-day stock returns. A Streamlit dashboard provides an interactive
+view of the results.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+### Command line pipeline
+
+Run the end-to-end analysis for a ticker:
+
+```bash
+python scripts/run_pipeline.py AAPL --days 30
+```
+
+### Streamlit dashboard
+
+Launch the dashboard:
+
+```bash
+streamlit run financial_sentiment/dashboard.py
+```
+
+## Tests
+
+```bash
+pytest
+```

--- a/financial_sentiment/__init__.py
+++ b/financial_sentiment/__init__.py
@@ -1,0 +1,3 @@
+"""Utilities for financial news sentiment analysis."""
+
+__all__ = []

--- a/financial_sentiment/dashboard.py
+++ b/financial_sentiment/dashboard.py
@@ -1,0 +1,53 @@
+"""Streamlit dashboard for visualizing sentiment-return correlations."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pandas as pd
+import streamlit as st
+
+from .data import compute_next_day_returns, fetch_headlines, fetch_price_history
+from .sentiment import aggregate_daily_sentiment, analyze_headlines
+from .model import run_regression
+
+
+def main() -> None:
+    """Render the Streamlit dashboard."""
+
+    st.title("Financial News Sentiment vs. Stock Returns")
+
+    ticker = st.text_input("Ticker symbol", value="AAPL")
+    days = st.number_input("Days of history", min_value=1, max_value=365, value=30)
+
+    end = date.today()
+    start = end - timedelta(days=days)
+
+    if st.button("Run analysis"):
+        with st.spinner("Fetching data..."):
+            headlines = fetch_headlines(ticker, start, end)
+            prices = fetch_price_history(ticker, start, end + timedelta(days=1))
+
+        if headlines.empty or prices.empty:
+            st.warning("No data returned for selection.")
+            return
+
+        sentiments = analyze_headlines(headlines["headline"])
+        headlines = pd.concat([headlines.reset_index(drop=True), sentiments], axis=1)
+        daily_sentiment = aggregate_daily_sentiment(headlines)
+        returns = compute_next_day_returns(prices)
+
+        results = run_regression(daily_sentiment, returns)
+
+        st.subheader("Regression Results")
+        st.json(results)
+
+        st.subheader("Daily Sentiment")
+        st.line_chart(daily_sentiment)
+
+        st.subheader("Next-day Returns")
+        st.line_chart(returns)
+
+
+if __name__ == "__main__":
+    main()

--- a/financial_sentiment/data.py
+++ b/financial_sentiment/data.py
@@ -1,0 +1,74 @@
+"""Data retrieval utilities for financial news and stock prices."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+import pandas as pd
+import yfinance as yf
+
+
+@dataclass
+class NewsItem:
+    """Representation of a single news headline."""
+
+    ticker: str
+    datetime: datetime
+    headline: str
+    publisher: str
+
+
+def fetch_headlines(ticker: str, start: datetime, end: datetime) -> pd.DataFrame:
+    """Fetch news headlines for a ticker between *start* and *end* dates.
+
+    Parameters
+    ----------
+    ticker:
+        Stock ticker symbol.
+    start:
+        Inclusive start datetime.
+    end:
+        Inclusive end datetime.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with columns ``[ticker, datetime, headline, publisher]``.
+    """
+
+    ticker_obj = yf.Ticker(ticker)
+    news_items = getattr(ticker_obj, "news", [])
+
+    rows = []
+    for item in news_items:
+        publish_time = datetime.fromtimestamp(item.get("providerPublishTime", 0))
+        if start <= publish_time <= end:
+            rows.append(
+                NewsItem(
+                    ticker=ticker,
+                    datetime=publish_time,
+                    headline=item.get("title", ""),
+                    publisher=item.get("publisher", ""),
+                ).__dict__
+            )
+
+    return pd.DataFrame(rows)
+
+
+def fetch_price_history(ticker: str, start: datetime, end: datetime) -> pd.Series:
+    """Download daily adjusted close prices for *ticker* in the date range."""
+
+    data = yf.download(ticker, start=start, end=end, progress=False)
+    return data["Adj Close"].sort_index()
+
+
+def compute_next_day_returns(prices: pd.Series) -> pd.Series:
+    """Compute next-day returns from a series of prices.
+
+    The return on day *t* is defined as ``(price[t+1] - price[t]) / price[t]``.
+    The final day is dropped as it has no subsequent value.
+    """
+
+    returns = prices.pct_change().shift(-1)
+    return returns.dropna()

--- a/financial_sentiment/model.py
+++ b/financial_sentiment/model.py
@@ -1,0 +1,50 @@
+"""Model utilities for correlating sentiment with stock returns."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+
+
+def prepare_regression_data(
+    sentiment: pd.Series, returns: pd.Series
+) -> pd.DataFrame:
+    """Join sentiment and return series on date and drop missing values."""
+
+    df = pd.concat([sentiment.rename("sentiment"), returns.rename("return")], axis=1)
+    return df.dropna()
+
+
+def run_regression(sentiment: pd.Series, returns: pd.Series) -> Dict[str, float]:
+    """Fit a linear regression of returns on sentiment.
+
+    Parameters
+    ----------
+    sentiment:
+        Series of daily sentiment scores indexed by date.
+    returns:
+        Series of next-day returns indexed by date.
+
+    Returns
+    -------
+    dict
+        Dictionary with ``coef``, ``intercept`` and ``r2`` values.
+    """
+
+    df = prepare_regression_data(sentiment, returns)
+    if df.empty:
+        return {"coef": 0.0, "intercept": 0.0, "r2": 0.0}
+
+    X = df[["sentiment"]]
+    y = df["return"]
+
+    model = LinearRegression()
+    model.fit(X, y)
+
+    return {
+        "coef": float(model.coef_[0]),
+        "intercept": float(model.intercept_),
+        "r2": float(model.score(X, y)),
+    }

--- a/financial_sentiment/sentiment.py
+++ b/financial_sentiment/sentiment.py
@@ -1,0 +1,79 @@
+"""Sentiment analysis utilities using a FinBERT model."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+import pandas as pd
+from transformers import AutoModelForSequenceClassification, AutoTokenizer, pipeline
+
+
+_FINBERT_MODEL = "ProsusAI/finbert"
+
+
+def get_finbert_pipeline(device: int = -1):
+    """Load a sentiment analysis pipeline using FinBERT.
+
+    Parameters
+    ----------
+    device:
+        Device to load the model on. ``-1`` uses CPU.
+    """
+
+    tokenizer = AutoTokenizer.from_pretrained(_FINBERT_MODEL)
+    model = AutoModelForSequenceClassification.from_pretrained(_FINBERT_MODEL)
+    return pipeline(
+        "sentiment-analysis",
+        model=model,
+        tokenizer=tokenizer,
+        return_all_scores=True,
+        device=device,
+    )
+
+
+def analyze_headlines(headlines: Iterable[str], nlp_pipeline=None) -> pd.DataFrame:
+    """Analyze a sequence of headlines and return sentiment scores.
+
+    Parameters
+    ----------
+    headlines:
+        Iterable of headline strings.
+    nlp_pipeline:
+        Preloaded HuggingFace ``pipeline``. If ``None``, a new FinBERT pipeline
+        will be created. Passing a pipeline allows callers to cache the model
+        across multiple invocations and simplifies testing.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with columns ``[headline, positive, negative, neutral, sentiment]``
+        where ``sentiment`` is ``positive - negative``.
+    """
+
+    if nlp_pipeline is None:
+        nlp_pipeline = get_finbert_pipeline()
+
+    rows = []
+    for text in headlines:
+        scores = nlp_pipeline(text)[0]
+        score_map = {s["label"].lower(): s["score"] for s in scores}
+        rows.append(
+            {
+                "headline": text,
+                **score_map,
+                "sentiment": score_map.get("positive", 0) - score_map.get("negative", 0),
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def aggregate_daily_sentiment(news_df: pd.DataFrame) -> pd.Series:
+    """Aggregate sentiment scores by calendar date."""
+
+    if news_df.empty:
+        return pd.Series(dtype=float)
+
+    news_df = news_df.copy()
+    news_df["date"] = news_df["datetime"].dt.date
+    return news_df.groupby("date")["sentiment"].mean()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pandas
+yfinance
+transformers
+torch
+scikit-learn
+streamlit

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+"""Command line interface for running the sentiment-return pipeline."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date, timedelta
+
+from financial_sentiment.data import (
+    compute_next_day_returns,
+    fetch_headlines,
+    fetch_price_history,
+)
+from financial_sentiment.sentiment import aggregate_daily_sentiment, analyze_headlines
+from financial_sentiment.model import run_regression
+
+
+def main() -> None:
+    """Entry point for the CLI."""
+
+    parser = argparse.ArgumentParser(
+        description="Correlate news sentiment with next-day stock returns."
+    )
+    parser.add_argument("ticker", help="Ticker symbol (e.g., AAPL)")
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=30,
+        help="Number of past days to analyze",
+    )
+
+    args = parser.parse_args()
+
+    end = date.today()
+    start = end - timedelta(days=args.days)
+
+    headlines = fetch_headlines(args.ticker, start, end)
+    if headlines.empty:
+        raise SystemExit("No headlines fetched")
+
+    prices = fetch_price_history(args.ticker, start, end + timedelta(days=1))
+    if prices.empty:
+        raise SystemExit("No price data fetched")
+
+    sentiments = analyze_headlines(headlines["headline"])
+    headlines = headlines.reset_index(drop=True).join(sentiments)
+    daily_sentiment = aggregate_daily_sentiment(headlines)
+    returns = compute_next_day_returns(prices)
+
+    results = run_regression(daily_sentiment, returns)
+    print(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -1,0 +1,40 @@
+"""Unit tests for sentiment utilities."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from financial_sentiment.sentiment import aggregate_daily_sentiment, analyze_headlines
+
+
+class DummyPipeline:
+    """Simple pipeline that returns deterministic scores for testing."""
+
+    def __call__(self, text):  # type: ignore[override]
+        return [
+            [
+                {"label": "positive", "score": 0.7},
+                {"label": "negative", "score": 0.2},
+                {"label": "neutral", "score": 0.1},
+            ]
+        ]
+
+
+def test_analyze_headlines() -> None:
+    df = analyze_headlines(["Stocks rally"], nlp_pipeline=DummyPipeline())
+    assert "sentiment" in df.columns
+    assert abs(df.loc[0, "sentiment"] - 0.5) < 1e-6
+
+
+def test_aggregate_daily_sentiment() -> None:
+    df = pd.DataFrame(
+        {
+            "datetime": pd.to_datetime(
+                ["2023-01-01 10:00", "2023-01-01 12:00", "2023-01-02 09:30"]
+            ),
+            "sentiment": [0.5, -0.1, 0.2],
+        }
+    )
+    agg = aggregate_daily_sentiment(df)
+    assert agg.loc[pd.Timestamp("2023-01-01").date()] == 0.2
+    assert agg.loc[pd.Timestamp("2023-01-02").date()] == 0.2


### PR DESCRIPTION
## Summary
- add modules to fetch Yahoo Finance headlines and price data
- run FinBERT sentiment analysis and aggregate daily scores
- correlate sentiment with next-day returns via linear regression and provide Streamlit dashboard

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a7831d1aa883318c3ccbb98012ec07